### PR TITLE
Fix barrel fluid rendering crash

### DIFF
--- a/src/main/java/exnihiloadscensio/barrel/modes/transform/BarrelModeFluidTransform.java
+++ b/src/main/java/exnihiloadscensio/barrel/modes/transform/BarrelModeFluidTransform.java
@@ -11,6 +11,7 @@ import exnihiloadscensio.registries.types.FluidTransformer;
 import exnihiloadscensio.texturing.Color;
 import exnihiloadscensio.tiles.TileBarrel;
 import exnihiloadscensio.util.BlockInfo;
+import exnihiloadscensio.util.LogUtil;
 import exnihiloadscensio.util.Util;
 import lombok.Getter;
 import lombok.Setter;
@@ -83,29 +84,28 @@ public class BarrelModeFluidTransform implements IBarrelMode {
 			EntityPlayer player, EnumFacing side, float hitX, float hitY, float hitZ) {
 		return false;
 	}
-
-	@Override
-	public TextureAtlasSprite getTextureForRender(TileBarrel barrel) {
-		if (progress < 0.5) {
-			if (inputStack == null || inputStack.getFluid().getBlock() == null)
-				return Util.getTextureFromBlockState(FluidRegistry.WATER.getBlock().getDefaultState());
-			return Util.getTextureFromBlockState(inputStack.getFluid().getBlock().getDefaultState());
-		}
-		else {
-			if (outputStack == null || outputStack.getFluid().getBlock() == null)
-				return Util.getTextureFromBlockState(FluidRegistry.WATER.getBlock().getDefaultState());
-			return Util.getTextureFromBlockState(outputStack.getFluid().getBlock().getDefaultState());
-		}
-	}
-
-	@Override
-	public Color getColorForRender() {
-		if (progress < 0.5) {
-			return Color.average(Util.whiteColor, Util.blackColor, (float) (progress/0.5));
-		}
-		return Color.average(Util.blackColor, Util.whiteColor, (float) ((progress-0.5)/0.5));
-	}
-
+    
+    @Override
+    public TextureAtlasSprite getTextureForRender(TileBarrel barrel)
+    {
+        if (progress < 0.5)
+        {
+            return Util.getTextureFromFluidStack(inputStack);
+        }
+        else
+        {
+            return Util.getTextureFromFluidStack(outputStack);
+        }
+    }
+    
+    @Override
+    public Color getColorForRender()
+    {
+        LogUtil.info(2 * Math.abs(progress - 0.5F));
+        
+        return Color.average(Util.blackColor, Util.whiteColor, 2 * Math.abs(progress - 0.5F));
+    }
+    
 	@Override
 	public float getFilledLevelForRender(TileBarrel barrel) {
 		return 1;

--- a/src/main/java/exnihiloadscensio/client/renderers/RenderBarrel.java
+++ b/src/main/java/exnihiloadscensio/client/renderers/RenderBarrel.java
@@ -13,45 +13,52 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 
-public class RenderBarrel extends TileEntitySpecialRenderer<TileBarrel> {
-
-	@Override
-	public void renderTileEntityAt(TileBarrel te, double x, double y, double z,
-			float partialTicks, int destroyStage) 
-	{
-		Tessellator tes = Tessellator.getInstance();
-		VertexBuffer wr = tes.getBuffer();
-
-		GlStateManager.pushMatrix();
-		GlStateManager.translate(x, y, z);
-		if (te.getMode() != null)
-		{
-			TextureAtlasSprite icon = te.getMode().getTextureForRender(te);
-			double minU = (double) icon.getMinU();
-			double maxU = (double) icon.getMaxU();
-			double minV = (double) icon.getMinV();
-			double maxV = (double) icon.getMaxV();
-
-			this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
-
-			wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR_NORMAL);
-			//wr.begin(GL11.GL_QUADS, new VertexFormat().addElement(DefaultVertexFormats.POSITION_3F).addElement(DefaultVertexFormats.COLOR_4UB).addElement(DefaultVertexFormats.NORMAL_3B));
-			float fillAmount = te.getMode().getFilledLevelForRender(te);
-			Color color = te.getMode().getColorForRender();
-			if (color == null)
-				color = Util.whiteColor;
-			wr.pos(0.125f,fillAmount,0.125f).tex(minU, minV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
-			wr.pos(0.125f,fillAmount,0.875f).tex(minU,maxV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
-			wr.pos(0.875f,fillAmount,0.875f).tex(maxU,maxV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
-			wr.pos(0.875f,fillAmount,0.125f).tex(maxU,minV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
-
-			tes.draw();
-		}
-
-		GlStateManager.disableBlend();
-		GlStateManager.enableLighting();
-		GlStateManager.popMatrix();
-
-	}
-
+public class RenderBarrel extends TileEntitySpecialRenderer<TileBarrel>
+{
+    @Override
+    public void renderTileEntityAt(TileBarrel tile, double x, double y, double z, float partialTicks, int destroyStage)
+    {
+        Tessellator tessellator = Tessellator.getInstance();
+        VertexBuffer buffer = tessellator.getBuffer();
+        
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(x, y, z);
+        
+        if (tile.getMode() != null)
+        {
+            float fillAmount = tile.getMode().getFilledLevelForRender(tile);
+            
+            if (fillAmount > 0)
+            {
+                Color color = tile.getMode().getColorForRender();
+                
+                if (color == null)
+                {
+                    color = Util.whiteColor;
+                }
+                
+                TextureAtlasSprite icon = tile.getMode().getTextureForRender(tile);
+                
+                double minU = (double) icon.getMinU();
+                double maxU = (double) icon.getMaxU();
+                double minV = (double) icon.getMinV();
+                double maxV = (double) icon.getMaxV();
+                
+                this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+                
+                buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR_NORMAL);
+                
+                buffer.pos(0.125f, fillAmount, 0.125f).tex(minU, minV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+                buffer.pos(0.125f, fillAmount, 0.875f).tex(minU, maxV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+                buffer.pos(0.875f, fillAmount, 0.875f).tex(maxU, maxV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+                buffer.pos(0.875f, fillAmount, 0.125f).tex(maxU, minV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+                
+                tessellator.draw();
+            }
+        }
+        
+        GlStateManager.disableBlend();
+        GlStateManager.enableLighting();
+        GlStateManager.popMatrix();
+    }
 }

--- a/src/main/java/exnihiloadscensio/util/Util.java
+++ b/src/main/java/exnihiloadscensio/util/Util.java
@@ -77,7 +77,22 @@ public class Util {
 		return Minecraft.getMinecraft().getBlockRendererDispatcher().getBlockModelShapes()
 		.getTexture(state);
 	}
-	
+
+    public static TextureAtlasSprite getTextureFromFluidStack(FluidStack stack)
+    {
+        if(stack.getFluid() != null)
+        {
+            Fluid fluid = stack.getFluid();
+            
+            if(fluid.getStill(stack) != null)
+            {
+                return Minecraft.getMinecraft().getTextureMapBlocks().getTextureExtry(fluid.getStill().toString());
+            }
+        }
+        
+        return Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite();
+    }
+    
 	public static boolean isSurroundingBlocksAtLeastOneOf(BlockInfo[] blocks, BlockPos pos, World world, int radius) {
 		ArrayList<BlockInfo> blockList = new ArrayList<BlockInfo>(Arrays.asList(blocks));
 		for (int xShift = -1*radius ; xShift <= radius ; xShift++) {


### PR DESCRIPTION
- Changed the way the renderer gets the texture for fluids (this is what
was crashing)
- Small changes to rendering code
- "Broken" fluids will now appear as a missing block texture instead of
water