### PR TITLE
Add support for fluid colors and block colors in crucible items/fluids

### DIFF
--- a/src/main/java/exnihiloadscensio/client/renderers/RenderCrucible.java
+++ b/src/main/java/exnihiloadscensio/client/renderers/RenderCrucible.java
@@ -2,8 +2,10 @@ package exnihiloadscensio.client.renderers;
 
 import org.lwjgl.opengl.GL11;
 
+import exnihiloadscensio.texturing.Color;
 import exnihiloadscensio.tiles.TileCrucible;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -19,6 +21,7 @@ public class RenderCrucible extends TileEntitySpecialRenderer<TileCrucible> {
 		Tessellator tes = Tessellator.getInstance();
 		VertexBuffer wr = tes.getBuffer();
 
+		RenderHelper.disableStandardItemLighting();
 		GlStateManager.pushMatrix();
 		GlStateManager.translate(x, y, z);
 		if (te.getTexture() != null)
@@ -28,18 +31,21 @@ public class RenderCrucible extends TileEntitySpecialRenderer<TileCrucible> {
 			double maxU = (double) icon.getMaxU();
 			double minV = (double) icon.getMinV();
 			double maxV = (double) icon.getMaxV();
+			
+			// determine the tint for the fluid
+			Color color = te.getColor();
 
 			this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
 
-			wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_NORMAL);
+			wr.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR_NORMAL);
 			//wr.begin(GL11.GL_QUADS, new VertexFormat().addElement(DefaultVertexFormats.POSITION_3F).addElement(DefaultVertexFormats.COLOR_4UB).addElement(DefaultVertexFormats.NORMAL_3B));
 			// Offset by bottome of crucible, which is 4 pixels above the base of the block
 			float fillAmount = (12F / 16F) * te.getFilledAmount() + (4F / 16F);
 			
-			wr.pos(0.125F, fillAmount, 0.125F).tex(minU, minV).normal(0, 1, 0).endVertex();
-			wr.pos(0.125F, fillAmount, 0.875F).tex(minU, maxV).normal(0, 1, 0).endVertex();
-			wr.pos(0.875F, fillAmount, 0.875F).tex(maxU, maxV).normal(0, 1, 0).endVertex();
-			wr.pos(0.875F, fillAmount, 0.125F).tex(maxU, minV).normal(0, 1, 0).endVertex();
+			wr.pos(0.125F, fillAmount, 0.125F).tex(minU, minV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+			wr.pos(0.125F, fillAmount, 0.875F).tex(minU, maxV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+			wr.pos(0.875F, fillAmount, 0.875F).tex(maxU, maxV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
+			wr.pos(0.875F, fillAmount, 0.125F).tex(maxU, minV).color(color.r, color.g, color.b, color.a).normal(0, 1, 0).endVertex();
 
 			tes.draw();
 		}
@@ -47,6 +53,7 @@ public class RenderCrucible extends TileEntitySpecialRenderer<TileCrucible> {
 		GlStateManager.disableBlend();
 		GlStateManager.enableLighting();
 		GlStateManager.popMatrix();
+		RenderHelper.enableStandardItemLighting();
 
 	}
 

--- a/src/main/java/exnihiloadscensio/client/renderers/RenderCrucible.java
+++ b/src/main/java/exnihiloadscensio/client/renderers/RenderCrucible.java
@@ -3,6 +3,7 @@ package exnihiloadscensio.client.renderers;
 import org.lwjgl.opengl.GL11;
 
 import exnihiloadscensio.texturing.Color;
+import exnihiloadscensio.texturing.SpriteColor;
 import exnihiloadscensio.tiles.TileCrucible;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -24,16 +25,17 @@ public class RenderCrucible extends TileEntitySpecialRenderer<TileCrucible> {
 		RenderHelper.disableStandardItemLighting();
 		GlStateManager.pushMatrix();
 		GlStateManager.translate(x, y, z);
-		if (te.getTexture() != null)
+		SpriteColor sprite = te.getSpriteAndColor();
+		if (sprite != null)
 		{
-			TextureAtlasSprite icon = te.getTexture();
+			TextureAtlasSprite icon = sprite.getSprite();
 			double minU = (double) icon.getMinU();
 			double maxU = (double) icon.getMaxU();
 			double minV = (double) icon.getMinV();
 			double maxV = (double) icon.getMaxV();
 			
-			// determine the tint for the fluid
-			Color color = te.getColor();
+			// determine the tint for the fluid/block
+			Color color = sprite.getColor();
 
 			this.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
 

--- a/src/main/java/exnihiloadscensio/texturing/SpriteColor.java
+++ b/src/main/java/exnihiloadscensio/texturing/SpriteColor.java
@@ -1,0 +1,13 @@
+package exnihiloadscensio.texturing;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+@AllArgsConstructor
+public class SpriteColor {
+    @Getter
+	private TextureAtlasSprite sprite;
+    @Getter
+	private Color color;
+}


### PR DESCRIPTION
Based on the comment from #113, added support for crucibles to tint fluids, and also added block color support while there. [Before](http://i.imgur.com/6513YMz.png)/[after](http://i.imgur.com/rdSv7Qm.png).

One thing worth noting is I basically copied the logic from the texture getter to the color one. It might make a bit more sense to wrap the result of the texture one in a wrapper object in order to return both the texture and the color at once so the logic only runs once (which I'll gladly do if wanted), but I was not sure what your policy on changing existing public functions is.