### PR TITLE
Transformation NPE crash

### DIFF
--- a/src/main/java/exnihiloadscensio/barrel/modes/fluid/BarrelModeFluid.java
+++ b/src/main/java/exnihiloadscensio/barrel/modes/fluid/BarrelModeFluid.java
@@ -174,7 +174,6 @@ public class BarrelModeFluid implements IBarrelMode {
 				List<FluidTransformer> transformers = FluidTransformRegistry
 						.getFluidTransformers(barrel.getTank().getFluid().getFluid().getName());
 
-				boolean found = false;
 				for (int radius = 0; radius <= 2; radius++) {
 					for (FluidTransformer transformer : transformers) {
 						if (!BarrelLiquidBlacklistRegistry.isBlacklisted(barrel.getTier(), transformer.getOutputFluid())
@@ -194,10 +193,9 @@ public class BarrelModeFluid implements IBarrelMode {
 							mode.setOutputStack(FluidRegistry.getFluidStack(transformer.getOutputFluid(), 1000));
 
 							PacketHandler.sendNBTUpdate(barrel);
-							found = true;
+							return;
 						}
 					}
-					if (found) break;
 				}
 			}
 		}

--- a/src/main/java/exnihiloadscensio/barrel/modes/transform/BarrelModeFluidTransform.java
+++ b/src/main/java/exnihiloadscensio/barrel/modes/transform/BarrelModeFluidTransform.java
@@ -112,7 +112,7 @@ public class BarrelModeFluidTransform implements IBarrelMode {
 
 	@Override
 	public void update(TileBarrel barrel) {
-		if (transformer == null) {
+		if (transformer == null && inputStack != null && outputStack != null) {
 			transformer = FluidTransformRegistry.getFluidTransformer(inputStack
 					.getFluid().getName(), outputStack.getFluid().getName());
 		}

--- a/src/main/java/exnihiloadscensio/util/Util.java
+++ b/src/main/java/exnihiloadscensio/util/Util.java
@@ -87,7 +87,7 @@ public class Util {
 
     public static TextureAtlasSprite getTextureFromFluidStack(FluidStack stack)
     {
-        if(stack.getFluid() != null)
+        if(stack != null && stack.getFluid() != null)
         {
             Fluid fluid = stack.getFluid();
             


### PR DESCRIPTION
Fixes #102 

The crash is caused by multiple transformers fighting over `inputStack`. The first one sets the tank contents to null, and every subsequent container takes that null value and assigns it to `inputStack`. This writes it to NBT and causes NPEs later on during render and update.

(Note: compilation was not tested as I couldn't set up the toolchain properly, but it is verified by editing and patching the bytecode of the compiled mod.)